### PR TITLE
Give a simple name to the module workers

### DIFF
--- a/module-rt/src/bootstrap.rs
+++ b/module-rt/src/bootstrap.rs
@@ -119,7 +119,7 @@ pub fn start<I: Ipc + 'static, T: UserModule + 'static>(args: Vec<String>) {
         exporting_service_pool: Arc::new(Mutex::new(ExportingServicePool::new())),
         ports: HashMap::new(),
         // TODO: decide thread pool size from the configuration
-        thread_pool: Arc::new(Mutex::new(ThreadPool::new(16))),
+        thread_pool: Arc::new(Mutex::new(ThreadPool::with_name("module_worker".to_owned(), 16))),
         shutdown_signal,
         bootstrap_finished: false,
     }) as Box<dyn FoundryModule>;

--- a/module-rt/tests/multiple.rs
+++ b/module-rt/tests/multiple.rs
@@ -202,6 +202,7 @@ fn link(modules: &[Module], single_export: bool) {
     }
 }
 
+#[allow(clippy::same_item_push)]
 #[test]
 fn multiple() {
     let mut module_names = Vec::new();
@@ -243,6 +244,7 @@ fn multiple() {
     }
 }
 
+#[allow(clippy::same_item_push)]
 #[test]
 fn multiple_single_shared_export() {
     let mut module_names = Vec::new();


### PR DESCRIPTION
Using a module name is better. Using module name is difficult than
this commit. This commit is a temporary commit until we set the module
name.